### PR TITLE
feat(movies): migrate app to use name column instead of title

### DIFF
--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,6 +3,11 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
+  if (payload.hasOwnProperty('title')) {
+    payload.name = payload.title;
+    Reflect.deleteProperty(payload, 'title');
+  }
+
   return new Movie().save(payload)
   .then((movie) => {
     return new Movie({ id: movie.id }).fetch();

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,12 +3,14 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
-  if (payload.hasOwnProperty('title')) {
-    payload.name = payload.title;
-    Reflect.deleteProperty(payload, 'title');
+  const payloadCopy = Object.assign({}, payload);
+
+  if (payloadCopy.hasOwnProperty('title')) {
+    payloadCopy.name = payloadCopy.title;
+    Reflect.deleteProperty(payloadCopy, 'title');
   }
 
-  return new Movie().save(payload)
+  return new Movie().save(payloadCopy)
   .then((movie) => {
     return new Movie({ id: movie.id }).fetch();
   });

--- a/lib/validators/movies/create.js
+++ b/lib/validators/movies/create.js
@@ -4,5 +4,6 @@ const Joi = require('joi');
 
 module.exports = Joi.object().keys({
   title: Joi.string().min(1).max(255).required(),
-  release_year: Joi.number().integer().min(1878).max(9999).optional()
+  release_year: Joi.number().integer().min(1878).max(9999).optional(),
+  name: Joi.forbidden()
 });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -7,30 +7,30 @@ describe('movie controller', () => {
 
   describe('create', () => {
 
-    const assertMovieCreated = function (payload, expTitle) {
+    const assertMovieCreated = function (payload, expectedName) {
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('name')).to.eql(expTitle);
+        expect(movie.get('name')).to.eql(expectedName);
 
         return new Movie({ id: movie.id }).fetch();
       })
       .then((movie) => {
-        expect(movie.get('name')).to.eql(expTitle);
+        expect(movie.get('name')).to.eql(expectedName);
       });
     };
 
     it('creates a movie with name', () => {
-      const expTitle = 'WALL-E';
-      const payload = { name: expTitle };
+      const expectedName = 'WALL-E';
+      const payload = { name: expectedName };
 
-      return assertMovieCreated(payload, expTitle);
+      return assertMovieCreated(payload, expectedName);
     });
 
     it('creates a movie with title', () => {
-      const expTitle = 'WALL-E';
-      const payload = { title: expTitle };
+      const expectedName = 'WALL-E';
+      const payload = { title: expectedName };
 
-      return assertMovieCreated(payload, expTitle);
+      return assertMovieCreated(payload, expectedName);
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -7,18 +7,30 @@ describe('movie controller', () => {
 
   describe('create', () => {
 
-    it('creates a movie', () => {
-      const payload = { title: 'WALL-E' };
-
+    const assertMovieCreated = function (payload, expTitle) {
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(expTitle);
 
         return new Movie({ id: movie.id }).fetch();
       })
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(expTitle);
       });
+    };
+
+    it('creates a movie with name', () => {
+      const expTitle = 'WALL-E';
+      const payload = { name: expTitle };
+
+      return assertMovieCreated(payload, expTitle);
+    });
+
+    it('creates a movie with title', () => {
+      const expTitle = 'WALL-E';
+      const payload = { title: expTitle };
+
+      return assertMovieCreated(payload, expTitle);
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -7,7 +7,7 @@ describe('movie controller', () => {
 
   describe('create', () => {
 
-    const assertMovieCreated = function (payload, expectedName) {
+    const assertMovieCreated = (payload, expectedName) => {
       return Controller.create(payload)
       .then((movie) => {
         expect(movie.get('name')).to.eql(expectedName);

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -13,7 +13,7 @@ describe('movie validator', () => {
       const result = Joi.validate(payload, MovieValidator);
 
       expect(result.error.details[0].path[0]).to.eql('name');
-      expect(result.error.details[0].type).to.eql('object.allowUnknown');
+      expect(result.error.details[0].type).to.eql('any.unknown');
     });
 
   });

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -5,6 +5,17 @@ const Joi = require('joi');
 const MovieValidator = require('../../lib/validators/movies/create');
 
 describe('movie validator', () => {
+  describe('name', () => {
+
+    it('is an invalid key', () => {
+      const payload = { title: 'test', name: 'test' };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('name');
+      expect(result.error.details[0].type).to.eql('object.allowUnknown');
+    });
+
+  });
 
   describe('title', () => {
 

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -5,6 +5,7 @@ const Joi = require('joi');
 const MovieValidator = require('../../lib/validators/movies/create');
 
 describe('movie validator', () => {
+
   describe('name', () => {
 
     it('is an invalid key', () => {


### PR DESCRIPTION
**What:** Changing app code to reference name column instead of title column.

**Why:** Part 2 of schema migration change.

**Details:**
- Writing title payload to name column in db
- Returning name column as title at API layer
- Updating unit tests